### PR TITLE
Update Foxglove protobuf definitions, use fixed integer types, use sec/nsec for Timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: arduino/setup-protoc@v1
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
@@ -26,3 +27,6 @@ jobs:
           else
             echo "Generated schemas are up to date!"
           fi
+
+      - name: Validate protobuf definitions
+        run: protoc --proto_path=proto proto/**/*.proto --descriptor_set_out=/dev/null

--- a/proto/foxglove/CameraCalibration.proto
+++ b/proto/foxglove/CameraCalibration.proto
@@ -1,0 +1,17 @@
+// https://foxglove.dev/docs/studio/messages/camera-calibration
+
+syntax = "proto3";
+
+import "foxglove/Timestamp.proto";
+package foxglove;
+
+message CameraCalibration {
+  Timestamp timestamp = 1;
+  fixed32 width = 2;
+  fixed32 height = 3;
+  string distortion_model = 4;
+  repeated double D = 5;
+  repeated double K = 6; // length 9
+  repeated double R = 7; // length 9
+  repeated double P = 8; // length 12
+}

--- a/proto/foxglove/Color.proto
+++ b/proto/foxglove/Color.proto
@@ -1,0 +1,12 @@
+// https://foxglove.dev/docs/studio/messages/color
+
+syntax = "proto3";
+
+package foxglove;
+
+message Color {
+  double r = 1;
+  double g = 2;
+  double b = 3;
+  double a = 4;
+}

--- a/proto/foxglove/CompressedImage.proto
+++ b/proto/foxglove/CompressedImage.proto
@@ -2,10 +2,11 @@
 
 syntax = "proto3";
 
+import "foxglove/Timestamp.proto";
 package foxglove;
 
 message CompressedImage {
-  uint64 timestamp = 1;
+  Timestamp timestamp = 1;
   string format = 2;
   bytes data = 3;
 }

--- a/proto/foxglove/ImageAnnotations.proto
+++ b/proto/foxglove/ImageAnnotations.proto
@@ -1,0 +1,42 @@
+// https://foxglove.dev/docs/studio/messages/image-annotations
+
+syntax = "proto3";
+
+import "foxglove/Timestamp.proto";
+import "foxglove/Color.proto";
+package foxglove;
+
+message ImageAnnotations {
+  CircleAnnotation circles = 1;
+  PointsAnnotation data = 2;
+
+  message CircleAnnotation {
+    Timestamp timestamp = 1;
+    Point2D position = 2;
+    double diameter = 3;
+    double thickness = 4;
+    Color fill_color = 5;
+    Color outline_color = 6;
+  }
+
+  message PointsAnnotation {
+    Timestamp timestamp = 1;
+    Type type = 2;
+    repeated Point2D points = 3;
+    repeated Color outline_colors = 4;
+    Color fill_color = 5;
+
+    enum Type {
+      UNKNOWN = 0;
+      POINTS = 1;
+      POLYGON = 2;
+      LINE_STRIP = 3;
+      LINE_LIST = 4;
+    }
+  }
+
+  message Point2D {
+    double x = 1;
+    double y = 2;
+  }
+}

--- a/proto/foxglove/JointState.proto
+++ b/proto/foxglove/JointState.proto
@@ -1,0 +1,12 @@
+// https://foxglove.dev/docs/studio/messages/compressed-image
+
+syntax = "proto3";
+
+package foxglove;
+
+message JointState {
+  repeated string name = 1;
+  repeated double position = 2;
+  repeated double velocity = 3;
+  repeated double effort = 4;
+}

--- a/proto/foxglove/JointState.proto
+++ b/proto/foxglove/JointState.proto
@@ -1,4 +1,4 @@
-// https://foxglove.dev/docs/studio/messages/compressed-image
+// https://foxglove.dev/docs/studio/messages/joint-state
 
 syntax = "proto3";
 

--- a/proto/foxglove/LocationFix.proto
+++ b/proto/foxglove/LocationFix.proto
@@ -2,10 +2,11 @@
 
 syntax = "proto3";
 
+import "foxglove/Timestamp.proto";
 package foxglove;
 
 message LocationFix {
-  uint64 timestamp = 1;
+  Timestamp timestamp = 1;
 
   double latitude = 2;
   double longitude = 3;

--- a/proto/foxglove/Log.proto
+++ b/proto/foxglove/Log.proto
@@ -2,12 +2,14 @@
 
 syntax = "proto3";
 
+import "foxglove/Timestamp.proto";
 package foxglove;
 
 message Log {
-  uint64 timestamp = 1;
+  Timestamp timestamp = 1;
 
   enum LogLevel {
+    UNKNOWN = 0;
     DEBUG = 1;
     INFO = 2;
     WARN = 3;
@@ -19,5 +21,5 @@ message Log {
   string message = 3;
   string name = 4;
   string file = 5;
-  uint32 line = 6;
+  fixed32 line = 6;
 }

--- a/proto/foxglove/RawImage.proto
+++ b/proto/foxglove/RawImage.proto
@@ -2,13 +2,14 @@
 
 syntax = "proto3";
 
+import "foxglove/Timestamp.proto";
 package foxglove;
 
 message RawImage {
-  uint64 timestamp = 1;
-  uint32 width = 2;
-  uint32 height = 3;
+  Timestamp timestamp = 1;
+  fixed32 width = 2;
+  fixed32 height = 3;
   string encoding = 4;
-  uint32 step = 5;
+  fixed32 step = 5;
   bytes data = 6;
 }

--- a/proto/foxglove/Timestamp.proto
+++ b/proto/foxglove/Timestamp.proto
@@ -1,0 +1,10 @@
+// https://foxglove.dev/docs/studio/messages/built-in-types
+
+syntax = "proto3";
+
+package foxglove;
+
+message Timestamp {
+  fixed32 sec = 1;
+  fixed32 nsec = 2;
+}


### PR DESCRIPTION
**Public-Facing Changes**
`foxglove.*` Protobuf schemas are updated to match documentation on the website.

**Description**
Relates to https://github.com/foxglove/studio/issues/3070